### PR TITLE
Added technique comparison and use std::span

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,15 +687,53 @@ always question them, and do you research.
 
 The motivation for this research came about when discovering how to do analysis 
 when a file is written. With prior background researching process hollowing and 
-doppelganing. I had theorized this might be possible. The goal is to provide 
+doppelganging. I had theorized this might be possible. The goal is to provide 
 better security. You cannot create a better lock without first understanding 
 how to break the old one.
+
+### Similar Techniques
+Herpaderping is similar to hollowing and doppelganging however there are some 
+key differences:
+
+#### Process Hollowing
+Process hollowing involves modifying the mapped section before execution 
+begins, this involves: `map -> modify section -> execute`. This differs from 
+herpaderping where there is no section modification. This is fairly easily 
+caught by security products by seeing there is a modification to the intended 
+execution path.
+
+#### Process Doppelganging
+Process doppelganging is closer to herpaderping. Doppelganging abuses 
+transacted file operations, this involves: 
+`transact -> write -> map -> rollback -> execute`. 
+In this scenario, the OS will create the image section and account for 
+transactions, so the cached image section is what you wrote to the transaction. 
+The OS has patched this. You may no longer map an image section when a file has 
+an active transaction. This differs from herpaderping in that herpaderping does 
+not rely on transacted file operations.
+
+### Comparison
+For reference, the generalized techniques: 
+| Type          | Technique                                         |
+| :------------ | :------------------------------------------------ |
+| Hollowing     | `map -> modify section -> execute`                |
+| Doppelganging | `transact -> write -> map -> rollback -> execute` |
+| Herpaderping  | `write -> map -> modify -> execute -> close`      |
+
+We can see the differences laid out here. While herpaderping is arguably 
+noisier than doppelganing, in that the malicious bits do hit the disk, we've 
+seen that security products are still incapable of detecting it. And the patch 
+for deppelganging is insufficient for preventing a malicious image section 
+from being mapped. 
+
+## Possible Solution
+There is not a clear fix here. It seems reasonable that preventing an image 
+section from being mapped/cached when there is write access to the file 
+should close the hole. However, that may or may not be a practical solution.
 
 ## Known Affected Platforms
 Below is a list of products and Windows OSes that have been tested as of 
 (7/14/2020). Tests were preformed with a known malicious binary.
-
-
 
 | Operating System                    | Version         | Vulnerable |
 | :---------------------------------- | :-------------- | :--------: |

--- a/source/ProcessHerpaderping/ProcessHerpaderping.vcxproj
+++ b/source/ProcessHerpaderping/ProcessHerpaderping.vcxproj
@@ -113,6 +113,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)ext\submodules\;$(SolutionDir)ext\submodules\phnt\;$(SolutionDir)ext\submodules\wil\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>pch.hpp</PrecompiledHeaderFile>
       <GenerateXMLDocumentationFiles>true</GenerateXMLDocumentationFiles>
+      <SupportJustMyCode>false</SupportJustMyCode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -133,6 +134,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)ext\submodules\;$(SolutionDir)ext\submodules\phnt\;$(SolutionDir)ext\submodules\wil\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>pch.hpp</PrecompiledHeaderFile>
       <GenerateXMLDocumentationFiles>true</GenerateXMLDocumentationFiles>
+      <SupportJustMyCode>false</SupportJustMyCode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/source/ProcessHerpaderping/herpaderp.cpp
+++ b/source/ProcessHerpaderping/herpaderp.cpp
@@ -14,8 +14,7 @@ HRESULT Herpaderp::ExecuteProcess(
     const std::wstring& TargetBinary,
     const std::wstring& FileName,
     const std::optional<std::wstring>& ReplaceWith,
-    const uint8_t* Pattern,
-    size_t PatternLength,
+    std::span<const uint8_t> Pattern, 
     bool WaitForProcess,
     bool HoldHandleExclusive)
 {
@@ -233,7 +232,6 @@ HRESULT Herpaderp::ExecuteProcess(
             hr = Utils::OverwriteFileAfterWithPattern(targetHandle.get(),
                                                       replaceWithSize,
                                                       Pattern,
-                                                      PatternLength, 
                                                       bytesWritten);
             if (FAILED(hr))
             {
@@ -262,8 +260,7 @@ HRESULT Herpaderp::ExecuteProcess(
         Utils::Log(Log::Success, L"Overwriting target with pattern");
 
         hr = Utils::OverwriteFileContentsWithPattern(targetHandle.get(),
-                                                     Pattern,
-                                                     PatternLength);
+                                                     Pattern);
         if (FAILED(hr))
         {
             Utils::Log(Log::Error, hr, L"Failed to write pattern over file");

--- a/source/ProcessHerpaderping/herpaderp.hpp
+++ b/source/ProcessHerpaderping/herpaderp.hpp
@@ -21,13 +21,10 @@ namespace Herpaderp
     /// </param>
     /// <param name="ReplaceWith">
     /// Optional, if provided the file is replaced with the content of this 
-    /// file. If not produced the file is overwritten with a pattern.
+    /// file. If not provided the file is overwritten with a pattern.
     /// </param>
     /// <param name="Pattern">
     /// Pattern used for obfuscation.
-    /// </param>
-    /// <param name="PatternLength">
-    /// Length of pattern buffer.
     /// </param>
     /// <param name="WaitForProcess">
     /// If true, function waits for the herpaderped process to exit.
@@ -43,8 +40,7 @@ namespace Herpaderp
         _In_ const std::wstring& TargetBinary,
         _In_ const std::wstring& FileName,
         _In_opt_ const std::optional<std::wstring>& ReplaceWith,
-        _In_ const uint8_t* Pattern,
-        _In_ size_t PatternLength,
+        _In_ std::span<const uint8_t> Pattern, 
         _In_ bool WaitForProcess,
         _In_ bool HoldHandleExclusive);
 

--- a/source/ProcessHerpaderping/main.cpp
+++ b/source/ProcessHerpaderping/main.cpp
@@ -16,7 +16,7 @@ namespace Constants
         L"Process Herpaderping Tool - Copyright (c) Johnny Shaw" 
     };
 
-    constexpr static std::array<BYTE, 4> Pattern{ '\x72', '\x6f', '\x66', '\x6c' };
+    constexpr static std::array<uint8_t, 4> Pattern{ '\x72', '\x6f', '\x66', '\x6c' };
 
     constexpr static size_t RandPatterLen{ 0x200 };
 }
@@ -254,9 +254,8 @@ int wmain(
     // Herpaderp wants a pattern to use for obfuscation, set that up here.
     //
     HRESULT hr;
+    std::span<const uint8_t> pattern = Constants::Pattern;
     std::vector<uint8_t> patternBuffer;
-    const uint8_t* pattern = Constants::Pattern.data();
-    size_t patternLength = Constants::Pattern.size();
 
     if (params.RandomObfuscation())
     {
@@ -272,15 +271,13 @@ int wmain(
                             L"Failed to generate random buffer");
             return EXIT_FAILURE;
         }
-        pattern = patternBuffer.data();
-        patternLength = patternBuffer.size();
+        pattern = std::span<const uint8_t>(patternBuffer);
     }
 
     hr = Herpaderp::ExecuteProcess(params.TargetBinary(), 
                                    params.FileName(), 
                                    params.ReplaceWith(), 
                                    pattern,
-                                   patternLength,
                                    params.WaitForProcess(),
                                    params.HoldFileExlusive());
     if (FAILED(hr))

--- a/source/ProcessHerpaderping/pch.hpp
+++ b/source/ProcessHerpaderping/pch.hpp
@@ -32,6 +32,7 @@
 #include <algorithm>
 #include <functional>
 #include <optional>
+#include <span>
 
 //
 // Third Party

--- a/source/ProcessHerpaderping/utils.cpp
+++ b/source/ProcessHerpaderping/utils.cpp
@@ -246,8 +246,7 @@ void Utils::Log(
 _Use_decl_annotations_
 HRESULT Utils::FillBufferWithPattern(
     std::vector<uint8_t>& Buffer,
-    const uint8_t* Pattern,
-    size_t PatternLength)
+    std::span<const uint8_t> Pattern)
 {
     if (Buffer.empty())
     {
@@ -257,14 +256,14 @@ HRESULT Utils::FillBufferWithPattern(
     auto bytesRemaining = Buffer.size();
     while (bytesRemaining > 0)
     {
-        auto len = (PatternLength > bytesRemaining ? 
+        auto len = (Pattern.size() > bytesRemaining ? 
                     bytesRemaining 
                     : 
-                    PatternLength);
+                    Pattern.size());
 
         std::memcpy(&Buffer[Buffer.size() - bytesRemaining],
-                    Pattern,
-                    len);
+                    Pattern.data(),
+                    Pattern.size());
 
         bytesRemaining -= len;
     }
@@ -389,8 +388,7 @@ HRESULT Utils::CopyFileByHandle(
 _Use_decl_annotations_
 HRESULT Utils::OverwriteFileContentsWithPattern(
     handle_t FileHandle,
-    const uint8_t* Pattern,
-    size_t PatternLength)
+    std::span<const uint8_t> Pattern)
 {
     uint64_t targetSize;
     RETURN_IF_FAILED(GetFileSize(FileHandle, targetSize));
@@ -401,16 +399,12 @@ HRESULT Utils::OverwriteFileContentsWithPattern(
     if (bytesRemaining > MaxFileBuffer)
     {
         buffer.resize(MaxFileBuffer);
-        RETURN_IF_FAILED(FillBufferWithPattern(buffer,
-                                               Pattern,
-                                               PatternLength));
+        RETURN_IF_FAILED(FillBufferWithPattern(buffer, Pattern));
     }
     else
     {
         buffer.resize(SCAST(size_t)(bytesRemaining));
-        RETURN_IF_FAILED(FillBufferWithPattern(buffer,
-                                               Pattern,
-                                               PatternLength));
+        RETURN_IF_FAILED(FillBufferWithPattern(buffer, Pattern));
     }
 
     while (bytesRemaining > 0)
@@ -418,9 +412,7 @@ HRESULT Utils::OverwriteFileContentsWithPattern(
         if (bytesRemaining < buffer.size())
         {
             buffer.resize(SCAST(size_t)(bytesRemaining));
-            RETURN_IF_FAILED(FillBufferWithPattern(buffer,
-                                                   Pattern,
-                                                   PatternLength));
+            RETURN_IF_FAILED(FillBufferWithPattern(buffer, Pattern));
         }
 
         DWORD bytesWritten = 0;
@@ -442,8 +434,7 @@ _Use_decl_annotations_
 HRESULT Utils::ExtendFileWithPattern(
     handle_t FileHandle,
     uint64_t NewFileSize,
-    const uint8_t* Pattern,
-    size_t PatternLength,
+    std::span<const uint8_t> Pattern,
     uint32_t& AppendedBytes)
 {
     AppendedBytes = 0;
@@ -464,16 +455,12 @@ HRESULT Utils::ExtendFileWithPattern(
     if (bytesRemaining > MaxFileBuffer)
     {
         buffer.resize(MaxFileBuffer);
-        RETURN_IF_FAILED(FillBufferWithPattern(buffer,
-                                               Pattern,
-                                               PatternLength));
+        RETURN_IF_FAILED(FillBufferWithPattern(buffer, Pattern));
     }
     else
     {
         buffer.resize(SCAST(size_t)(bytesRemaining));
-        RETURN_IF_FAILED(FillBufferWithPattern(buffer,
-                                               Pattern,
-                                               PatternLength));
+        RETURN_IF_FAILED(FillBufferWithPattern(buffer, Pattern));
     }
 
     while (bytesRemaining > 0)
@@ -483,9 +470,7 @@ HRESULT Utils::ExtendFileWithPattern(
         if (bytesRemaining < buffer.size())
         {
             buffer.resize(SCAST(size_t)(bytesRemaining));
-            RETURN_IF_FAILED(FillBufferWithPattern(buffer,
-                                                   Pattern,
-                                                   PatternLength));
+            RETURN_IF_FAILED(FillBufferWithPattern(buffer, Pattern));
         }
 
         RETURN_IF_WIN32_BOOL_FALSE(WriteFile(FileHandle,
@@ -507,8 +492,7 @@ _Use_decl_annotations_
 HRESULT Utils::OverwriteFileAfterWithPattern(
     handle_t FileHandle,
     uint64_t FileOffset,
-    const uint8_t* Pattern,
-    size_t PatternLength,
+    std::span<const uint8_t> Pattern,
     uint32_t& WrittenBytes)
 {
     WrittenBytes = 0;
@@ -529,16 +513,12 @@ HRESULT Utils::OverwriteFileAfterWithPattern(
     if (bytesRemaining > MaxFileBuffer)
     {
         buffer.resize(MaxFileBuffer);
-        RETURN_IF_FAILED(FillBufferWithPattern(buffer,
-                                               Pattern,
-                                               PatternLength));
+        RETURN_IF_FAILED(FillBufferWithPattern(buffer, Pattern));
     }
     else
     {
         buffer.resize(SCAST(size_t)(bytesRemaining));
-        RETURN_IF_FAILED(FillBufferWithPattern(buffer,
-                                               Pattern,
-                                               PatternLength));
+        RETURN_IF_FAILED(FillBufferWithPattern(buffer, Pattern));
     }
 
     while (bytesRemaining > 0)
@@ -548,9 +528,7 @@ HRESULT Utils::OverwriteFileAfterWithPattern(
         if (bytesRemaining < buffer.size())
         {
             buffer.resize(SCAST(size_t)(bytesRemaining));
-            RETURN_IF_FAILED(FillBufferWithPattern(buffer,
-                                                   Pattern,
-                                                   PatternLength));
+            RETURN_IF_FAILED(FillBufferWithPattern(buffer, Pattern));
         }
 
         RETURN_IF_WIN32_BOOL_FALSE(WriteFile(FileHandle,

--- a/source/ProcessHerpaderping/utils.hpp
+++ b/source/ProcessHerpaderping/utils.hpp
@@ -219,17 +219,13 @@ namespace Utils
     /// <param name="Pattern">
     /// Pattern to write into the buffer.
     /// </param>
-    /// <param name="PatternLength">
-    /// Length of the Pattern buffer.
-    /// </param>
     /// <returns>
     /// Success when the buffer is filled with the pattern. Failure if Buffer 
     /// is empty.
     /// </returns>
     _Must_inspect_result_ HRESULT FillBufferWithPattern(
         _Inout_ std::vector<uint8_t>& Buffer,
-        _In_reads_(PatternLength) const uint8_t* Pattern,
-        _In_ size_t PatternLength);
+        _In_ std::span<const uint8_t> Pattern);
 
     /// <summary>
     /// Generates a buffer of random bytes of a given length.
@@ -312,8 +308,7 @@ namespace Utils
     /// </returns>
     _Must_inspect_result_ HRESULT OverwriteFileContentsWithPattern(
         _In_ handle_t FileHandle,
-        _In_reads_(PatternLength) const uint8_t* Pattern,
-        _In_ size_t PatternLength);
+        _In_ std::span<const uint8_t> Pattern);
 
     /// <summary>
     /// Extends file to meet a new size writes a pattern to the extension.
@@ -327,9 +322,6 @@ namespace Utils
     /// <param name="Pattern">
     /// Pattern to use to extend the target file with.
     /// </param>
-    /// <param name="PatternLength">
-    /// Length of PatternBuffer.
-    /// </param>
     /// <param name="AppendedBytes">
     /// Number of bytes appended.
     /// </param>
@@ -339,8 +331,7 @@ namespace Utils
     _Must_inspect_result_ HRESULT ExtendFileWithPattern(
         _In_ handle_t FileHandle,
         _In_ uint64_t NewFileSize,
-        _In_reads_(PatternLength) const uint8_t* Pattern,
-        _In_ size_t PatternLength,
+        _In_ std::span<const uint8_t> Pattern,
         _Out_ uint32_t& AppendedBytes);
 
     /// <summary>
@@ -355,9 +346,6 @@ namespace Utils
     /// <param name="Pattern">
     /// Pattern to use to extend the target file with.
     /// </param>
-    /// <param name="PatternLength">
-    /// Length of PatternBuffer.
-    /// </param>
     /// <param name="WrittenBytes">
     /// Number of bytes written.
     /// </param>
@@ -367,8 +355,7 @@ namespace Utils
     _Must_inspect_result_ HRESULT OverwriteFileAfterWithPattern(
         _In_ handle_t FileHandle,
         _In_ uint64_t FileOffset,
-        _In_reads_(PatternLength) const uint8_t* Pattern,
-        _In_ size_t PatternLength,
+        _In_ std::span<const uint8_t> Pattern,
         _Out_ uint32_t& WrittenBytes);
     
     /// <summary>


### PR DESCRIPTION
Added technique comparison to README, comparing herpaderping to doppelgangin and hollowing.
Changed pattern uint8_t*/size_t pairs to use std::span instead.