### PR TITLE
Added close file early option

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,6 +841,9 @@ Usage:
                            Without this option the handle has full share
                            access and is closed as soon as possible.
   -u,--do-not-flush-file   Does not flush file after overwrite.
+  -c,--close-file-early    Closes file before thread creation (before the
+                           process notify callback fires in the kernel).
+                           Not valid with "--exclusive" option.
 ```
 
 ## Cloning and Building

--- a/source/ProcessHerpaderping/herpaderp.hpp
+++ b/source/ProcessHerpaderping/herpaderp.hpp
@@ -9,6 +9,31 @@
 
 namespace Herpaderp
 {
+#pragma warning(push)
+#pragma warning(disable : 4634)  // xmldoc: discarding XML document comment for invalid target 
+    /// <summary>
+    /// Waits for process to exit before returning.
+    /// </summary>
+    constexpr static uint32_t FlagWaitForProcess = 0x00000001ul;
+
+    /// <summary>
+    /// Opens and hold the target file handle exclusive for as long as 
+    /// reasonable. This flag is incompatible with FlagCloseFileEarly.
+    /// </summary>
+    constexpr static uint32_t FlagHoldHandleExclusive = 0x00000002ul;
+
+    /// <summary>
+    /// Flushes file buffers of target file.
+    /// </summary>
+    constexpr static uint32_t FlagFlushFile = 0x00000004ul;
+
+    /// <summary>
+    /// Closes the file handle early, before creating the initial thread 
+    /// (before process notification would fire in the kernel). This flag is 
+    /// not compatible with FlagHoldHandleExclusive.
+    /// </summary>
+    constexpr static uint32_t FlagCloseFileEarly = 0x00000008ul;
+#pragma warning(pop)
 
     /// <summary>
     /// Executes process herpaderping.
@@ -26,15 +51,8 @@ namespace Herpaderp
     /// <param name="Pattern">
     /// Pattern used for obfuscation.
     /// </param>
-    /// <param name="WaitForProcess">
-    /// If true, function waits for the herpaderped process to exit.
-    /// </param>
-    /// <param name="HoldHandleExclusive">
-    /// If true, the function creates the target file with exclusive access 
-    /// and holds the handle open longer.
-    /// </param>
-    /// <param name="FlushFile">
-    /// Flushes file after overwrite if true, if false the file is not flushed.
+    /// <param name="Flags">
+    /// Flags controlling behavior of herpaderping (Herpaderp::FlagXxx).
     /// </param>
     /// <returns>
     /// Success if the herpaderping executed. Failure otherwise.
@@ -44,8 +62,6 @@ namespace Herpaderp
         _In_ const std::wstring& TargetFileName,
         _In_opt_ const std::optional<std::wstring>& ReplaceWithFileName,
         _In_ std::span<const uint8_t> Pattern, 
-        _In_ bool WaitForProcess,
-        _In_ bool HoldHandleExclusive,
-        _In_ bool FlushFile);
+        _In_ uint32_t Flags);
 
 }

--- a/source/ProcessHerpaderping/pch.hpp
+++ b/source/ProcessHerpaderping/pch.hpp
@@ -69,6 +69,15 @@
 #define CCAST(_X_) const_cast<_X_>
 #define DCAST(_X_) dynamic_cast<_X_>
 #define Add2Ptr(_P_, _X_) RCAST(void*)(RCAST(uintptr_t)(_P_) + _X_)
+#ifndef FlagOn
+#define FlagOn(_F_, _X_) ((_F_) & (_X_))
+#endif
+#ifndef SetFlag
+#define SetFlag(_F_, _X_) ((_F_) |= (_X_))
+#endif
+#ifndef ClearFlag
+#define ClearFlag(_F_, _X_) ((_F_) &= ~(_X_))
+#endif
 using handle_t = HANDLE;
 
 //

--- a/source/ProcessHerpaderping/utils.cpp
+++ b/source/ProcessHerpaderping/utils.cpp
@@ -67,7 +67,8 @@ HRESULT Utils::HandleCommandLineArgs(
     IArgumentParser& Parser)
 {
     if (SUCCEEDED(CheckForHelpOptions(Argc, Argv)) ||
-        FAILED(Parser.ParseArguments(Argc, Argv)))
+        FAILED(Parser.ParseArguments(Argc, Argv)) ||
+        FAILED(Parser.ValidateArguments()))
     {
         if (Header.has_value())
         {

--- a/source/ProcessHerpaderping/utils.hpp
+++ b/source/ProcessHerpaderping/utils.hpp
@@ -52,6 +52,14 @@ namespace Utils
         /// </returns>
         virtual std::wstring_view GetUsage() const = 0;
 
+        /// <summary>
+        /// Provides the interface an opportunity to validate the parsed 
+        /// arguments. If the arguments are invalid (for example, two options 
+        /// are used that may not be specified together) the implementation 
+        /// may return failure here to indicate the arguments are invalid.
+        /// </summary>
+        _Must_inspect_result_ virtual HRESULT ValidateArguments() const = 0;
+
     protected:
         IArgumentParser() = default;
     };
@@ -463,7 +471,4 @@ namespace Utils
         _In_opt_ const std::optional<std::wstring>& ShellInfo,
         _In_opt_ const std::optional<std::wstring>& RuntimeData);
 
-
 }
-
-


### PR DESCRIPTION
For the sake of testing, I've added the option `--close-file-early`. This option will close the file handle before creating the initial thread in the process. This actually doesn't affect the state of the process notify callback, the `EPROCESS` still has no `ImageFilePointer`, the `_PS_CREATE_NOTIFY_INFO` receives the `FileObject` from the section in the same state it would otherwise:

```
Object: ffffc2039128e2d0  Type: (ffffc203714fe900) File
    ObjectHeader: ffffc2039128e2a0 (new version)
    HandleCount: 0  PointerCount: 15
    Directory Object: 00000000  Name: \Users\jxy\Desktop\lol.exe {HarddiskVolume3}
```
```
1: kd> dx (nt!_EPROCESS*)@rcx
(nt!_EPROCESS*)@rcx                 : 0xffffc2037adbc0c0 [Type: _EPROCESS *]
    [+0x000] Pcb              [Type: _KPROCESS]
...
    [+0x5a0] ImageFilePointer : 0x0 [Type: _FILE_OBJECT *]
    [+0x5a8] ImageFileName    [Type: unsigned char [15]]
...
```
```
1: kd> dx (nt!_FILE_OBJECT*)0xffffc2039128e2d0
(nt!_FILE_OBJECT*)0xffffc2039128e2d0                 : 0xffffc2039128e2d0 [Type: _FILE_OBJECT *]
    [+0x000] Type             : 5 [Type: short]
    [+0x002] Size             : 216 [Type: short]
    [+0x008] DeviceObject     : 0xffffc20372484a50 : Device for "\Driver\volmgr" [Type: _DEVICE_OBJECT *]
    [+0x010] Vpb              : 0xffffc2037246c060 [Type: _VPB *]
    [+0x018] FsContext        : 0xffff8387282ae170 [Type: void *]
    [+0x020] FsContext2       : 0xffff838726020a80 [Type: void *]
    [+0x028] SectionObjectPointer : 0xffffc203911adbc8 [Type: _SECTION_OBJECT_POINTERS *]
    [+0x030] PrivateCacheMap  : 0x0 [Type: void *]
    [+0x038] FinalStatus      : 0 [Type: long]
    [+0x040] RelatedFileObject : 0xffffc2039128f590 [Type: _FILE_OBJECT *]
    [+0x048] LockOperation    : 0x0 [Type: unsigned char]
    [+0x049] DeletePending    : 0x0 [Type: unsigned char]
    [+0x04a] ReadAccess       : 0x1 [Type: unsigned char]
    [+0x04b] WriteAccess      : 0x1 [Type: unsigned char]
    [+0x04c] DeleteAccess     : 0x0 [Type: unsigned char]
    [+0x04d] SharedRead       : 0x1 [Type: unsigned char]
    [+0x04e] SharedWrite      : 0x1 [Type: unsigned char]
    [+0x04f] SharedDelete     : 0x1 [Type: unsigned char]
    [+0x050] Flags            : 0x44042 [Type: unsigned long]
    [+0x058] FileName         : "\Users\jxy\Desktop\lol.exe" [Type: _UNICODE_STRING]
    [+0x068] CurrentByteOffset : {327680} [Type: _LARGE_INTEGER]
    [+0x070] Waiters          : 0x0 [Type: unsigned long]
    [+0x074] Busy             : 0x0 [Type: unsigned long]
    [+0x078] LastLock         : 0x0 [Type: void *]
    [+0x080] Lock             [Type: _KEVENT]
    [+0x098] Event            [Type: _KEVENT]
    [+0x0b0] CompletionContext : 0x0 [Type: _IO_COMPLETION_CONTEXT *]
    [+0x0b8] IrpListLock      : 0x0 [Type: unsigned __int64]
    [+0x0c0] IrpList          [Type: _LIST_ENTRY]
    [+0x0d0] FileObjectExtension : 0x0 [Type: void *]
```