### PR TITLE
Fixed remote parameter write again

### DIFF
--- a/source/ProcessHerpaderping/main.cpp
+++ b/source/ProcessHerpaderping/main.cpp
@@ -235,7 +235,14 @@ private:
     std::wstring m_TargetBinary;
     std::wstring m_FileName;
     std::optional<std::wstring> m_ReplaceWith{ std::nullopt };
-    uint32_t m_LoggingMask{ 0xfffffffful };
+    uint32_t m_LoggingMask
+    {
+        Log::Success |
+        Log::Information |
+        Log::Warning |
+        Log::Error |
+        Log::Context
+    };
     bool m_Quiet{ false };
     bool m_RandomObfuscation{ false };
     uint32_t m_HerpaderpFlags

--- a/source/ProcessHerpaderping/utils.hpp
+++ b/source/ProcessHerpaderping/utils.hpp
@@ -471,16 +471,4 @@ namespace Utils
         _In_opt_ const std::optional<std::wstring>& ShellInfo,
         _In_opt_ const std::optional<std::wstring>& RuntimeData);
 
-    /// <summary>
-    /// Re-base an address from an original base address to another.
-    /// </summary>
-    /// <param name="Address">Address to re-base.</param>
-    /// <param name="Base">Original base address.</param>
-    /// <param name="NewBase">New base address.</param>
-    /// <returns>Success if the Address is re-based.</returns>
-    _Must_inspect_result_ HRESULT RebaseAddress(
-        _Inout_ void** Address,
-        _In_ void* Base,
-        _In_ void* NewBase);
-
 }


### PR DESCRIPTION
The previous attempt to fix generating and writing the remote parameters into the process (https://github.com/jxy-s/herpaderping/pull/14) did not account for new fields in the process parameter structure, this resulted in failure to "rebase" the parameter pointers and would result in failure on older OSes.

This approach, while fine, was noob-ish since omitting `RTL_USER_PROC_PARAMS_NORMALIZED` will "de-normalize" the parameters via `RtlDeNormalizeProcessParams`. This converts the pointers in the parameter block to offsets. Then, `LdrpInitializeProcess` will call `RtlNormalizeProcessParameters` when the process starts and fix up the pointers. There is one exception, the `Environment` pointer needs manually offset to after the base parameter data, which is the size of the structure plus the `Length` field.

Special thanks to @lcrobin for collaborating on this fix!